### PR TITLE
Add conditional logic for event tracking

### DIFF
--- a/rTap.js
+++ b/rTap.js
@@ -279,9 +279,11 @@ function rTapPostReplacement(){
     if (jQuery('.lp-pom-form').length) {
       jQuery('.lp-pom-form')[0].children[0].inf_custom_rTapId.value = cookie.get('adiV');
     }
-    ga('send', 'event', 'Page', 'pageview', 'ResponseTap ID', {
+    if (window.ga && ga.loaded) {
+      ga('send', 'event', 'Page', 'pageview', 'ResponseTap ID', {
       'dimension2':  cookie.get('adiV'),
       nonInteraction: true
-    });
+      });
+    }
   }
 }


### PR DESCRIPTION
Firefox is now blocking tracking scripts by default. To avoid errors, added conditional logic so that Google Analytics event only fires if tracking script is present.